### PR TITLE
fix: rename and relocate permissions

### DIFF
--- a/src/main/java/com/github/syr0ws/minewaypoints/util/Permission.java
+++ b/src/main/java/com/github/syr0ws/minewaypoints/util/Permission.java
@@ -4,8 +4,8 @@ public enum Permission {
 
     COMMAND_WAYPOINTS("command.waypoints"),
     COMMAND_WAYPOINTS_CREATE("command.waypoints.create"),
-    COMMAND_WAYPOINTS_RENAME("command.waypoints.reload"),
-    COMMAND_WAYPOINTS_RELOCATE("command.waypoints.reload"),
+    COMMAND_WAYPOINTS_RENAME("command.waypoints.rename"),
+    COMMAND_WAYPOINTS_RELOCATE("command.waypoints.relocate"),
     COMMAND_WAYPOINTS_SHARE("command.waypoints.share");
 
     private static final String PERMISSION_PREFIX = "minewaypoints";


### PR DESCRIPTION
Permission for commands `/waypoints rename` and `/waypoints relocate` was `command.waypoints.reload` instead of being `command.waypoints.rename` and `command.waypoints.relocate` respectively.